### PR TITLE
chore(package): allows npm versions >= 7.24.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   },
   "engines": {
-    "npm": "7.24.2"
+    "npm": ">= 7.24.2"
   },
   "private": false,
   "files": [


### PR DESCRIPTION
## What is the current behavior?

User have to use the EXACT version 7.24.2 of npm.

## What is the new behavior?

User can use npm version >= 7.24.2.